### PR TITLE
Reorder reset and add to pool to avoid adding connections with remain…

### DIFF
--- a/driver/src/main/java/pgnio/ConnectionPool.java
+++ b/driver/src/main/java/pgnio/ConnectionPool.java
@@ -2,6 +2,9 @@ package pgnio;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import pgnio.QueryReadyConnection.AutoCommit;
+
+import java.nio.channels.ClosedChannelException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.*;
@@ -22,6 +25,7 @@ public class ConnectionPool implements AutoCloseable {
   protected static final Logger log = Logger.getLogger(ConnectionPool.class.getName());
   protected final Config config;
   protected final BlockingQueue<CompletableFuture<QueryReadyConnection.AutoCommit>> connections;
+  protected final ConcurrentLinkedDeque<QueryReadyConnection.AutoCommit> opened;
   protected volatile boolean closed;
   /**
    * The number of connections we can still create during {@link #borrowConnection()} if there are none currently
@@ -35,6 +39,7 @@ public class ConnectionPool implements AutoCloseable {
   public ConnectionPool(Config config) {
     this.config = config;
     connections = new LinkedBlockingQueue<>(config.poolSize);
+    opened = new ConcurrentLinkedDeque<>();
     // If we are eagerly loading, create all of the connections now
     if (config.poolConnectEagerly) {
       log.log(Level.FINE, "Creating {0} pool connections eagerly", config.poolSize);
@@ -69,20 +74,15 @@ public class ConnectionPool implements AutoCloseable {
     CompletableFuture<QueryReadyConnection.AutoCommit> fut = null;
     try {
       // If there are some remaining for first creation, we can create anew instead of waiting
-      if (remainingNewConnectionsOnBorrow.get() > 0) {
-        fut = connections.poll();
-        if (fut == null) {
-          int preDecrementValue = remainingNewConnectionsOnBorrow.getAndDecrement();
-          if (preDecrementValue > 0) {
-            // Non-blocking get, then create since we have room
-            if (log.isLoggable(Level.FINE))
-              log.log(Level.FINE,
-                  "No connections available; lazily creating one, {0} connections remaining to be lazily created",
-                  preDecrementValue - 1);
-            fut = newConnection();
-          } else {
-            remainingNewConnectionsOnBorrow.set(0);
-          }
+      fut = connections.poll();
+      if (fut == null) {
+        int decrementedValue;
+        if ((decrementedValue = remainingNewConnectionsOnBorrow.getAndUpdate(i -> Math.max(0, i-1))) > 0) {
+          if (log.isLoggable(Level.FINE))
+            log.log(Level.FINE,
+                "No connections available; lazily creating one, {0} connections remaining to be lazily created",
+                decrementedValue);
+          fut = newConnection();
         }
       }
       // If the above didn't happen, we have to block on reading from the queue
@@ -118,7 +118,9 @@ public class ConnectionPool implements AutoCloseable {
   }
 
   protected CompletableFuture<QueryReadyConnection.AutoCommit> newConnection() {
-    return config.connector.apply(config);
+    CompletableFuture<AutoCommit> answer = config.connector.apply(config);
+    answer.thenAccept(opened::add);
+    return answer;
   }
 
   /**
@@ -136,11 +138,17 @@ public class ConnectionPool implements AutoCloseable {
         connections.put(newConnection());
       } else {
         // We have to remove all subscriptions
-        connections.put(conn.fullReset().whenComplete((__, ___) -> {
+        conn.fullReset().whenComplete((__, ___) -> {
           conn.notices().unsubscribeAll();
           conn.notifications().unsubscribeAll();
           conn.parameterStatuses().unsubscribeAll();
-        }));
+          if(!connections.add(CompletableFuture.completedFuture(conn)) ) {
+            try {
+              remainingNewConnectionsOnBorrow.incrementAndGet();
+              conn.close();
+            } catch (ExecutionException | InterruptedException e) {}
+          }
+        });
       }
     } catch (InterruptedException e) { throw new RuntimeException(e); }
   }
@@ -163,7 +171,12 @@ public class ConnectionPool implements AutoCloseable {
       Function<QueryReadyConnection.AutoCommit, CompletableFuture<T>> fn) {
     return borrowConnection(waitForConnTimeout, waitForConnUnit).
         // Handle exception early even on borrow
-        whenComplete((__, ex) -> { if (ex != null) returnConnection(null); }).
+        whenComplete((conn, ex) -> {
+          if (ex != null) {
+            opened.remove(conn);
+            returnConnection(null);
+          }
+        }).
         // Otherwise release no matter what happens in fn
         thenCompose(conn -> {
           // Make the call, wrapping even direct exceptions into the future
@@ -184,14 +197,23 @@ public class ConnectionPool implements AutoCloseable {
   /** Empty the pool, mark it closed, and terminate all connections being held */
   public CompletableFuture<Void> terminateAll() {
     closed = true;
-    List<CompletableFuture<QueryReadyConnection.AutoCommit>> futs = new ArrayList<>();
-    connections.drainTo(futs);
-    CompletableFuture[] closedFuts = new CompletableFuture[futs.size()];
-    for (int i = 0; i < closedFuts.length; i++) closedFuts[i] = futs.get(i).thenCompose(Connection::terminate);
+    List<QueryReadyConnection.AutoCommit> futs = new ArrayList<>(opened);
+    CompletableFuture<?>[] closedFuts = new CompletableFuture[opened.size()];
+    for (int i = 0; i < closedFuts.length; i++) closedFuts[i] = futs.get(i).terminate();
+    opened.clear();
+    connections.clear();
     return CompletableFuture.allOf(closedFuts);
   }
 
   /** Call {@link #terminateAll()} and wait for completion */
   @Override
-  public void close() throws ExecutionException, InterruptedException { terminateAll().get(); }
+  public void close() throws ExecutionException, InterruptedException {
+    try {
+      terminateAll().get();
+    } catch(ExecutionException e) {
+      if(!(e.getCause() instanceof ClosedChannelException)) {
+        throw e;
+      }
+    }
+  }
 }

--- a/driver/src/test/java/pgnio/ConnectionPoolTest.java
+++ b/driver/src/test/java/pgnio/ConnectionPoolTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 public class ConnectionPoolTest extends DbTestBase {
@@ -90,13 +91,21 @@ public class ConnectionPoolTest extends DbTestBase {
     try (ConnectionPool pool = new ConnectionPool(newDefaultConfig().poolSize(5))) {
       CountDownLatch firstLatch = new CountDownLatch(1);
       CountDownLatch secondLatch = new CountDownLatch(1);
-      CompletableFuture<Long> firstCount = pool.withConnection(c -> waitOn(getConnectionCount(c), firstLatch));
-      CompletableFuture<Long> secondCount = pool.withConnection(c ->
-          waitOn(secondLatch).thenCompose(__ -> getConnectionCount(c)));
-      firstLatch.countDown();
+      CompletableFuture<Long> firstCount = new CompletableFuture<>();
+      pool.withConnection(c -> {
+        try {
+		  firstCount.complete(getConnectionCount(c).get());
+		} catch (InterruptedException | ExecutionException e) {
+		  firstCount.completeExceptionally(e);
+		}
+        return waitOn(firstLatch);
+      });
+      CompletableFuture<Long> secondCount = firstCount.thenCompose(____-> pool.withConnection(c ->
+          waitOn(secondLatch).thenCompose(__ -> getConnectionCount(c))));
       Assert.assertEquals(1L, firstCount.get().longValue());
       secondLatch.countDown();
       Assert.assertEquals(2L, secondCount.get().longValue());
+      firstLatch.countDown();
     }
   }
 

--- a/driver/src/test/java/pgnio/EmbeddedDb.java
+++ b/driver/src/test/java/pgnio/EmbeddedDb.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermission;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -170,6 +171,12 @@ public interface EmbeddedDb {
                 Files.readAllBytes(Paths.get(getClass().getResource("keys/server.crt").toURI())));
             Files.write(dataDir.resolve("server.key"),
                 Files.readAllBytes(Paths.get(getClass().getResource("keys/server.key").toURI())));
+            try {
+              Set<PosixFilePermission> perms = new HashSet<PosixFilePermission>();
+              perms.add(PosixFilePermission.OWNER_READ);
+              perms.add(PosixFilePermission.OWNER_WRITE);
+              Files.setPosixFilePermissions(dataDir.resolve("server.key"), perms);
+            } catch (Exception ex) { }
           } catch (Exception e) { throw new RuntimeException(e); }
           // As a special case, if this is "runas" on Windows then we have to
           //  add these as string pieces inside the last quote


### PR DESCRIPTION
…ing work.  Utilize atomic operations to avoid set(0) at wrong time concurrently.